### PR TITLE
feat(): add ElementInternals support for things like formAssociated, …

### DIFF
--- a/src/internal/element-internals.js
+++ b/src/internal/element-internals.js
@@ -1,0 +1,68 @@
+import { __DEV__ } from "./env";
+import { _emit } from "./logging";
+
+export function createInternalsController(host, Component) {
+  let internals = null;
+  let requested = false;
+  let didSetFormValue = false;
+  let didSetValidity = false;
+
+  const name = Component.is || Component.name;
+
+  function attach() {
+    internals = host.attachInternals();
+
+    if (!__DEV__) return internals;
+
+    const _setFormValue = internals.setFormValue.bind(internals);
+    const _setValidity = internals.setValidity.bind(internals);
+
+    internals.setFormValue = (...args) => {
+      didSetFormValue = true;
+      return _setFormValue(...args);
+    };
+
+    internals.setValidity = (...args) => {
+      didSetValidity = true;
+
+      if (!didSetFormValue) {
+        _emit('VALIDITY_WITHOUT_FORM_VALUE', { name });
+      }
+
+      return _setValidity(...args);
+    };
+
+    return internals;
+  }
+
+  function get() {
+    requested = true;
+
+    if (__DEV__) {
+      if (!Component.formAssociated) {
+        _emit('INTERNALS_WITHOUT_FORM_ASSOCIATION', { name });
+      }
+
+      if (typeof host.attachInternals !== 'function') {
+        _emit('INTERNALS_UNSUPPORTED', { name });
+        return null;
+      }
+    }
+
+    if (!internals) attach();
+    return internals;
+  }
+
+  function audit() {
+    if (
+      !requested ||
+      !internals ||
+      didSetFormValue ||
+      didSetValidity
+    ) return;
+
+    _emit('INTERNALS_UNUSED', { name });
+  }
+
+  return { get, audit };
+}

--- a/src/internal/logging/messages.js
+++ b/src/internal/logging/messages.js
@@ -204,5 +204,65 @@ export const MESSAGES = Object.freeze({
         'This may be leftover scaffolding.'
       )
     }
-  }
+  },
+
+  VALIDITY_WITHOUT_FORM_VALUE: {
+    kind: 'warn',
+    category: 'element-internals',
+    summary: 'setValidity called before setFormValue',
+
+    format({ name }, { chalky }) {
+      return lines(
+        chalky.bold(this.summary),
+        '',
+        `In the form-associated custom element "${name}", setValidity was called before setFormValue.`,
+        'This may lead to unexpected behavior in some browsers.'
+      )
+    }
+  },
+
+  INTERNALS_WITHOUT_FORM_ASSOCIATION: {
+    kind: 'warn',
+    category: 'element-internals',
+    summary: 'attachInternals called on non-form-associated custom element',
+
+    format({ name }, { chalky }) {
+      return lines(
+        chalky.bold(this.summary),
+        '',
+        `The custom element "${name}" is not form-associated, but attachInternals was called.`,
+        'Element internals are only supported on form-associated custom elements.'
+      )
+    }
+  },
+
+  INTERNALS_UNUSED: {
+    kind: 'warn',
+    category: 'element-internals',
+    summary: 'ElementInternals created but never used',
+
+    format({ name }, { chalky }) {
+      return lines(
+        chalky.bold(this.summary),
+        '',
+        `The ElementInternals for the custom element "${name}" were created but never used.`,
+        'If internals are not needed, consider omitting attachInternals calls.'
+      )
+    }
+  },
+
+  INTERNALS_UNSUPPORTED: {
+    kind: 'warn',
+    category: 'element-internals',
+    summary: 'attachInternals called in unsupported environment',
+
+    format({ name }, { chalky }) {
+      return lines(
+        chalky.bold(this.summary),
+        '',
+        `The custom element "${name}" called attachInternals, but the environment does not support it.`,
+        'Element internals may not be available in all browsers.'
+      )
+    }
+  },
 })


### PR DESCRIPTION
…a11y, etc.

NOTE: an example, e.g. `glint-input`, is STILL needed and should be delivered asap.